### PR TITLE
Fix population fetch query

### DIFF
--- a/utils/budget_location_data.rb
+++ b/utils/budget_location_data.rb
@@ -43,7 +43,7 @@ class BudgetLocationData
   def population(location, year)
     year.downto(year - 2).map do |y|
       found = raw_data.find do |item|
-        id = [location.ine_code, y, GobiertoBudgetsData::GobiertoBudgets::POPULATION_TYPE].join("/")
+        id = [location.id, y, GobiertoBudgetsData::GobiertoBudgets::POPULATION_TYPE].join("/")
         item["_id"] == id
       end
 


### PR DESCRIPTION
The population was not being read successfully, leaving a lot of entries with no amount per inhabitant.